### PR TITLE
logging: Enable logging output to also go to console

### DIFF
--- a/.resinci.yml
+++ b/.resinci.yml
@@ -1,0 +1,7 @@
+---
+docker:
+  builds:
+    - path: .
+      dockerfile: Dockerfile
+      docker_repo: resin/resin-base-ui
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/resin-base:v4.3.0
+FROM resin/resin-base:v4.4.0
 
 ENV NGINX_VERSION 1.12.1-1~stretch
 ENV YARN_VERSION=0.27.5-1


### PR DESCRIPTION
This change allows output to be captured by the Supervisor
on resinOS devices when run as a service.

Connects-to: #16
Change-type: patch
Signed-off-by: Heds Simons <heds@resin.io>
---- Autogenerated Waffleboard Connection: Connects to #16