### PR TITLE
dns: Ensure DNS is prioritised over MDNS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/resin-base:v4.4.0
+FROM resin/resin-base:v4.4.1
 
 ENV NGINX_VERSION 1.12.1-1~stretch
 ENV YARN_VERSION=0.27.5-1


### PR DESCRIPTION
Updates `resin-base` to ensure DNS is prioritised
over MDNS, ensuring `.local` aliases are resolved
before those published on the local subnet.

Connects-to: #18
Change-type: patch
Signed-off-by: Heds Simons <heds@resin.io>